### PR TITLE
Fixed crash with extra comments in model atom

### DIFF
--- a/source/read_modelatom.f
+++ b/source/read_modelatom.f
@@ -16,7 +16,7 @@
       character modid(maxn)*40,bla*2
       integer iunit,modnlevel,modion(maxn),i
       real modenergy(maxn),abundance,mass,modg(maxn)
-      logical header
+      logical header,header2,header3
 
       open(iunit,file=modelatomfile,status='old')
       header=.true.
@@ -30,8 +30,22 @@
             write(bla,20) species(2:2)
             species=bla
           endif
-          read(iunit,*) abundance,mass
-          read(iunit,*) modnlevel
+          header2=.true.
+          do while (header2)
+            read(iunit,10,end=99) oneline
+            if (oneline(1:1).ne.'*') then
+              read(oneline,*) abundance,mass
+              header2=.false.
+            endif
+          enddo
+          header3=.true.
+          do while (header3)
+            read(iunit,10,end=99) oneline
+            if (oneline(1:1).ne.'*') then
+              read(oneline,*) modnlevel
+              header3=.false.
+            endif
+          enddo
           header=.false.
         endif
       enddo


### PR DESCRIPTION
Fixed crash when there are extra comments in the model atom file. For example, if there are comments after name of the atom, but before the abundance or number of lines (e.g. * ABUND      AWGT or * NK     NLINE   NCONT   NRFIX) it would crash. Now added check for header while loop to skip any comments in-between.