### PR TITLE
Fixed bug where last depth point is not read in <3D> STAGGER

### DIFF
--- a/interpolator/interpol_multi.f
+++ b/interpolator/interpol_multi.f
@@ -448,7 +448,7 @@ c      enddo
       endif
 
       do k=1,ndepth_ref
-        if (taus(k,out).lt.5) then
+        if (taus(k,out).le.5) then
           ndepth_final = k
         endif
        enddo

--- a/interpolator/interpol_multi_nlte.f
+++ b/interpolator/interpol_multi_nlte.f
@@ -811,7 +811,7 @@ c         enddo
 c      end if
 
        do k=1,ndepth_ref
-        if (taus(k,out).lt.5) then
+        if (taus(k,out).le.5) then
           ndepth_final = k
         endif
        enddo

--- a/interpolator/interpol_multi_nlte_gfort.f
+++ b/interpolator/interpol_multi_nlte_gfort.f
@@ -811,7 +811,7 @@ c         enddo
 c      end if
 
        do k=1,ndepth_ref
-        if (taus(k,out).lt.5) then
+        if (taus(k,out).le.5) then
           ndepth_final = k
         endif
        enddo

--- a/source/spectrum.inc
+++ b/source/spectrum.inc
@@ -20,7 +20,7 @@
 * to decrease these numbers, as arrays will be of size 
 * real*4: NDP*lpoint
 *
-      PARAMETER (NDP=100,NRAYS=130,lpoint=1000000)
+      PARAMETER (NDP=101,NRAYS=130,lpoint=1000000)
 *
 *  equation of state parameters   (for tabs and absko)
 *


### PR DESCRIPTION
In the interpolators the last depth point was not saved, resulting in only 100 depth points beingused, instead of all 101 as in the actual model atmosphere. Not sure if that caused any issues, but in NLTE there were 101 departure coefficient computed. Not sure if that could have an effect (since # of departure coefficients =/= depth points). By default TS only can  use up to 100 depth points, so had to change spectrum.inc as well to 101.

Cheers to SP for identifying the bug.