### PR TITLE
Added ability for interpolator MULTI to skip comment after NDEP

### DIFF
--- a/interpolator/interpol_multi.f
+++ b/interpolator/interpol_multi.f
@@ -101,6 +101,9 @@ c    JMG: 2020 converted format to interpolate models in MULTI format as opposed
       external :: blend_103
       real, external :: inf,sup
       real, dimension(8,3) :: lin_dif,power
+
+******NS
+      character line*256   ! a string variable to hold each line of the file
       
       INTERFACE reec
         subroutine resample(taus,tauR,T,Pe,Pg,xit,rr,xkapref)
@@ -196,7 +199,11 @@ c 78   format('model',i2,'  Teff=',f8.0,'  logg=',f5.2,'  z=',f6.2)
         read(imod,*)
         read(imod,*) ndepth(file)
         do k=1, ndepth(file)
-          read(imod,*) taus_aux(k,file), T_aux(k,file), NE_aux(k,file),
+          read(imod,'(A)') line    ! read a line as a string
+          if (line(1:1) .eq. "*") then
+            read(imod,'(A)') line  ! if the line starts with "*", it's a comment, so read the next line
+          endif
+          read(line,*) taus_aux(k,file), T_aux(k,file), NE_aux(k,file),
      &                 V_aux(k,file), Vturb_aux(k,file)
         enddo
         verif=verif.and.(ndepth(file).eq.ndepth(1))

--- a/interpolator/interpol_multi_nlte.f
+++ b/interpolator/interpol_multi_nlte.f
@@ -137,6 +137,9 @@ c      parameter (nlte_file=3)
       real :: abu_min, abu_max
       real, dimension(nfile) :: abu_temp
 
+******NS
+      character line*256   ! a string variable to hold each line of the file
+
       real y000
       real y001
       real y010
@@ -272,7 +275,11 @@ c 78   format('model',i2,'  Teff=',f8.0,'  logg=',f5.2,'  z=',f6.2)
         read(imod,*)
         read(imod,*) ndepth(file)
         do k=1, ndepth(file)
-          read(imod,*) taus_aux(k,file), T_aux(k,file), NE_aux(k,file),
+          read(imod,'(A)') line    ! read a line
+          if (line(1:1) .eq. "*") then
+            read(imod,'(A)') line  ! if the line starts with "*", it's a comment, so read the next line
+          endif
+          read(line,*) taus_aux(k,file), T_aux(k,file), NE_aux(k,file),
      &                 V_aux(k,file), Vturb_aux(k,file)
         enddo
         verif=verif.and.(ndepth(file).eq.ndepth(1))

--- a/interpolator/interpol_multi_nlte_gfort.f
+++ b/interpolator/interpol_multi_nlte_gfort.f
@@ -137,6 +137,9 @@ c      parameter (nlte_file=3)
       real :: abu_min, abu_max
       real, dimension(nfile) :: abu_temp
 
+******NS
+      character line*256   ! a string variable to hold each line of the file
+
       real y000
       real y001
       real y010
@@ -272,7 +275,11 @@ c 78   format('model',i2,'  Teff=',f8.0,'  logg=',f5.2,'  z=',f6.2)
         read(imod,*)
         read(imod,*) ndepth(file)
         do k=1, ndepth(file)
-          read(imod,*) taus_aux(k,file), T_aux(k,file), NE_aux(k,file),
+          read(imod,*) line    ! read a line
+          if (line(1:1) .eq. "*") then
+            read(imod,*) line  ! if the line starts with "*", it's a comment, so read the next line
+          endif
+          read(line,*) taus_aux(k,file), T_aux(k,file), NE_aux(k,file),
      &                 V_aux(k,file), Vturb_aux(k,file)
         enddo
         verif=verif.and.(ndepth(file).eq.ndepth(1))


### PR DESCRIPTION
Normally MULTI formatted files are expected to have comment after NDEP. E.g.:

`* NDEP
101
*
blah blah`

But if there was a `*` after `101`, then the interpolator would not be able to handle it. Old <3D> files did not have the "extra" expected `*` so the bug never occurred in e.g. TSFitPy, but then TS and interpolator would not be able to use the exactly same formatted model atmospheres. Now interpolator can handle the comment after NDEP, just like TS is expecting from the MULTI formatted atmosphere.