### PR TITLE
Fixed bug where too low abundances were not interpolated

### DIFF
--- a/interpolator/interpol_modeles_nlte.f
+++ b/interpolator/interpol_modeles_nlte.f
@@ -290,7 +290,7 @@ c      endif
           endif
         enddo
         abu_min = 99999999999.
-        abu_max = 0.
+        abu_max = -1000.
         do cnt1 = 1, nlte_file
            if  (nlte_file.le.20000.and.
      &         abu_ref.le.11.99999) then

--- a/interpolator/interpol_modeles_nlte_gfort.f
+++ b/interpolator/interpol_modeles_nlte_gfort.f
@@ -291,7 +291,7 @@ c      endif
           endif
         enddo
         abu_min = 99999999999.
-        abu_max = 0.
+        abu_max = -1000.
         do cnt1 = 1, nlte_file
            if  (nlte_file.le.20000.and.
      &         abu_ref.le.11.99999) then

--- a/interpolator/interpol_multi_nlte.f
+++ b/interpolator/interpol_multi_nlte.f
@@ -319,7 +319,7 @@ c         print*, n_pos(cnt), n_pos1(cnt)
           endif
         enddo
         abu_min = 99999999999.
-        abu_max = 0.
+        abu_max = -1000.
         do cnt1 = 1, nlte_file
            if  (nlte_file.le.190.and.
      &         abu_ref.le.11.99999) then

--- a/interpolator/interpol_multi_nlte_gfort.f
+++ b/interpolator/interpol_multi_nlte_gfort.f
@@ -319,7 +319,7 @@ c         print*, n_pos(cnt), n_pos1(cnt)
           endif
         enddo
         abu_min = 99999999999.
-        abu_max = 0.
+        abu_max = -1000.
         do cnt1 = 1, nlte_file
            if  (nlte_file.le.20000.and.
      &         abu_ref.le.11.99999) then


### PR DESCRIPTION
If the abundance of an element is too low, it should have correctly identified limits of the max abundance inside the grid. However it did not, if the grid went below A(X) = 0. Fixed so that it can correctly go down to abundances of -1000 (limit case basically).